### PR TITLE
Rotate LAT wafers differently depending on type

### DIFF
--- a/s4sim/hardware/config.py
+++ b/s4sim/hardware/config.py
@@ -1269,7 +1269,12 @@ def sim_nominal():
                         woff[ttyp] += 1
                         break
                     off += 1
-        tb["wafer_angle"] = [-90.0 for tw in range(1)] # Degrees
+        if ttyp == "CHLAT_HF" or ttyp == "SPLAT_HF":
+            # These are hex wafers
+            tb["wafer_angle"] = [-90.0 for tw in range(1)] # Degrees
+        else:
+            # These are rhombi-hex wafers
+            tb["wafer_angle"] = [0.0 for tw in range(1)] # Degrees
         if tindx < 170:
             # CHLAT platescale
             tb["platescale"] = 0.003964


### PR DESCRIPTION
LAT wafers start at different zero points of rotation depending on whether they are hex packed or rhombihex. This change applies different rotations in those two cases so that the final wafer orientations are aligned.