### PR TITLE
New SAT layouts for Chile

### DIFF
--- a/s4sim/hardware/config.py
+++ b/s4sim/hardware/config.py
@@ -1745,7 +1745,7 @@ def sim_nominal():
     tele["fwhm"] = lfwhm
     telescopes["LAT2"] = tele
 
-    #from the DSR
+    #SAT beams
     sfwhm = OrderedDict()
     sfwhm["SAT_f030"] = 100.9
     sfwhm["SAT_f040"] = 74.4

--- a/s4sim/hardware/config.py
+++ b/s4sim/hardware/config.py
@@ -380,14 +380,14 @@ def sim_nominal():
     bnd["low"] = 21.5
     bnd["high"] = 28.0
     bnd["bandpass"] = ""
-    bnd["NET"] = 180.0
+    bnd["NET"] = 246.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.20620
-    bnd["C"] = 0.73082
-    bnd["NET_corr"] = 1.04
-    bnd["pwv_poly"] = 0.965911, 0.105767, 0.001339
+    bnd["A"] = 0.16528
+    bnd["C"] = 0.78412
+    bnd["NET_corr"] = 1.02
+    bnd["pwv_poly"] = 0.897869, 0.102015, 0.000842
     bands["SAT_f030"] = bnd
 
     bnd = OrderedDict()
@@ -395,14 +395,14 @@ def sim_nominal():
     bnd["low"] = 28.0
     bnd["high"] = 45.0
     bnd["bandpass"] = ""
-    bnd["NET"] = 172.0
+    bnd["NET"] = 155.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.38157
-    bnd["C"] = 0.50229
-    bnd["NET_corr"] = 1.01
-    bnd["pwv_poly"] = 0.993008, 0.021647, 0.000420
+    bnd["A"] = 0.26123
+    bnd["C"] = 0.65913
+    bnd["NET_corr"] = 1.04
+    bnd["pwv_poly"] = 0.980612, 0.019172, 0.000355
     bands["SAT_f040"] = bnd
 
     bnd = OrderedDict()
@@ -470,14 +470,14 @@ def sim_nominal():
     bnd["low"] = 74.8
     bnd["high"] = 95.2
     bnd["bandpass"] = ""
-    bnd["NET"] = 283.0
+    bnd["NET"] = 259.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.42240
-    bnd["C"] = 0.44933
-    bnd["NET_corr"] = 1.03
-    bnd["pwv_poly"] = 0.980246, 0.060988, 0.001717
+    bnd["A"] = 0.29948
+    bnd["C"] = 0.60926
+    bnd["NET_corr"] = 1.02
+    bnd["pwv_poly"] = 0.947782, 0.051301, 0.001293
     bands["SAT_f085"] = bnd
 
     bnd = OrderedDict()
@@ -485,14 +485,14 @@ def sim_nominal():
     bnd["low"] = 129.1
     bnd["high"] = 161.0
     bnd["bandpass"] = ""
-    bnd["NET"] = 286.0
+    bnd["NET"] = 311.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.23936
-    bnd["C"] = 0.68768
-    bnd["NET_corr"] = 1.00
-    bnd["pwv_poly"] = 0.921380, 0.242478, 0.007618
+    bnd["A"] = 0.22746
+    bnd["C"] = 0.70314
+    bnd["NET_corr"] = 1.01
+    bnd["pwv_poly"] = 0.829576, 0.167357, 0.004298
     bands["SAT_f145"] = bnd
 
     bnd = OrderedDict()
@@ -500,14 +500,14 @@ def sim_nominal():
     bnd["low"] = 83.6
     bnd["high"] = 106.4
     bnd["bandpass"] = ""
-    bnd["NET"] = 244.0
+    bnd["NET"] = 240.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.33734
-    bnd["C"] = 0.55996
+    bnd["A"] = 0.24287
+    bnd["C"] = 0.68291
     bnd["NET_corr"] = 1.02
-    bnd["pwv_poly"] = 0.971560, 0.087835, 0.002376
+    bnd["pwv_poly"] = 0.930327, 0.068508, 0.001668
     bands["SAT_f095"] = bnd
 
     bnd = OrderedDict()
@@ -515,14 +515,14 @@ def sim_nominal():
     bnd["low"] = 138.0
     bnd["high"] = 172.1
     bnd["bandpass"] = ""
-    bnd["NET"] = 307.0
+    bnd["NET"] = 365.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.22772
-    bnd["C"] = 0.70281
-    bnd["NET_corr"] = 1.00
-    bnd["pwv_poly"] = 0.888059, 0.345337, 0.010558
+    bnd["A"] = 0.24578
+    bnd["C"] = 0.67924
+    bnd["NET_corr"] = 1.02
+    bnd["pwv_poly"] = 0.777297, 0.219235, 0.005073
     bands["SAT_f155"] = bnd
 
     bnd = OrderedDict()
@@ -590,14 +590,14 @@ def sim_nominal():
     bnd["low"] = 198.0
     bnd["high"] = 256.0
     bnd["bandpass"] = ""
-    bnd["NET"] = 626.0
+    bnd["NET"] = 731.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.26877
-    bnd["C"] = 0.64938
+    bnd["A"] = 0.31587
+    bnd["C"] = 0.58833
     bnd["NET_corr"] = 1.01
-    bnd["pwv_poly"] = 0.854979, 0.442977, 0.027418
+    bnd["pwv_poly"] = 0.710954, 0.278116, 0.013059
     bands["SAT_f220"] = bnd
 
     bnd = OrderedDict()
@@ -605,14 +605,14 @@ def sim_nominal():
     bnd["low"] = 256.0
     bnd["high"] = 315.0
     bnd["bandpass"] = ""
-    bnd["NET"] = 1511.0
+    bnd["NET"] = 1845.0
     bnd["fknee"] = 50.0
     bnd["fmin"] = 0.01
     bnd["alpha"] = 1.0
-    bnd["A"] = 0.31260
-    bnd["C"] = 0.59246
-    bnd["NET_corr"] = 1.00
-    bnd["pwv_poly"] = 0.814634, 0.560931, 0.051506
+    bnd["A"] = 0.37748
+    bnd["C"] = 0.50869
+    bnd["NET_corr"] = 1.01
+    bnd["pwv_poly"] = 0.642882, 0.337500, 0.022291
     bands["SAT_f280"] = bnd
 
     cnf["bands"] = bands

--- a/s4sim/hardware/config.py
+++ b/s4sim/hardware/config.py
@@ -632,17 +632,17 @@ def sim_nominal():
         "SAT_MFH": (12) * 3,
         "CHLAT_HF": 19*2,
         "SPLAT_HF": 18,
-        "SAT_HF": (6 + 6) * 2,
+        "SAT_HF": (12) * 2,
     }
     wpac = {
     	"CHLAT_ULF": "RP",
         "SPLAT_ULF": "RP",
         "CHLAT_LF": "RP",
         "SPLAT_LF": "RP",
-        "SAT_LF": "RP",
+        "SAT_LF": "HP",
         "CHLAT_MF": "RP",
         "SPLAT_MF": "RP",
-        "SAT_MFL": "RP",
+        "SAT_MFL": "HP",
         "SAT_MFH": "HP",
         "CHLAT_HF": "HP",
         "SPLAT_HF": "HP",
@@ -653,11 +653,11 @@ def sim_nominal():
         "SPLAT_ULF": 27,
         "CHLAT_LF": 48,
         "SPLAT_LF": 48,
-        "SAT_LF": 12,
+        "SAT_LF": 19,
         "CHLAT_MF": 432,
         "SPLAT_MF": 432,
-        "SAT_MFL": 147,
-        "SAT_MFH": 169,
+        "SAT_MFL": 217,
+        "SAT_MFH": 271,
         "CHLAT_HF": 469,
         "SPLAT_HF": 469,
         "SAT_HF": 469,
@@ -667,11 +667,11 @@ def sim_nominal():
         "SPLAT_ULF": 21.1,
         "CHLAT_LF": 16.1,
         "SPLAT_LF": 16.1,
-        "SAT_LF": 31.1,
+        "SAT_LF": 26.0,
         "CHLAT_MF": 5.3,
         "SPLAT_MF": 5.3,
-        "SAT_MFL": 9.5,
-        "SAT_MFH": 8.94,
+        "SAT_MFL": 7.65,
+        "SAT_MFH": 6.85,
         "CHLAT_HF": 5.2,
         "SPLAT_HF": 5.2,
         "SAT_HF": 5.2,
@@ -713,8 +713,8 @@ def sim_nominal():
         "SAT_LF": [],
         "CHLAT_MF": [210,220],
         "SPLAT_MF": [210,220],
-        "SAT_MFL": [70,75],
-        "SAT_MFH": [0,91],
+        "SAT_MFL": [0,127],
+        "SAT_MFH": [0,169],
         "CHLAT_HF": [0,331],
         "SPLAT_HF": [0,331],
         "SAT_HF": [0,331],
@@ -1308,14 +1308,14 @@ def sim_nominal():
         tubes[nm] = tb
 
     stubes = [
-        "SAT_MFH",
-        "SAT_MFH",
-        "SAT_HF",
         "SAT_MFL",
         "SAT_MFH",
         "SAT_HF",
         "SAT_MFL",
+        "SAT_MFH",
+        "SAT_HF",
         "SAT_MFL",
+        "SAT_MFH",
         "SAT_LF",
     ]
     stube_toasthex_pos = [0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -1351,7 +1351,7 @@ def sim_nominal():
                 30.0,
             ]
             # 30 deg, 10008 detectors/band
-            tb["platescale"] = 0.069437
+            tb["platescale"] = 0.070093/0.9909
             tb["FOV_cut"] = 30.0
         elif ttyp == "SAT_MFL":
             for tw in range(12):
@@ -1364,21 +1364,21 @@ def sim_nominal():
                             break
                         off += 1
             tb["wafer_angle"] = [ # Degrees
-                0.0,
-                0.0,
-                0.0,
-                -60.0,
-                -60.0,
-                0.0,
-                0.0,
-                60.0,
-                60.0,
-                180.0,
-                180.0,
-                0.0,
+                30.0,
+                30.0,
+                30.0,
+                -150.0,
+                -150.0,
+                30.0,
+                30.0,
+                30.0,
+                -30.0,
+                90.0,
+                30.0,
+                30.0,
             ]
             # 30 deg, 3048 detectors/band
-            tb["platescale"] = 0.0699
+            tb["platescale"] = 0.070093/0.9905
             tb["FOV_cut"] = 30.0
         elif ttyp == "SAT_MFH":
             for tw in range(12):
@@ -1405,7 +1405,7 @@ def sim_nominal():
                 30.0,
             ]
             # 30 deg, 3552 det/band
-            tb["platescale"] = 0.069777
+            tb["platescale"] = 0.070093/0.9931
             tb["FOV_cut"] = 30.0
         else:
             for tw in range(12):
@@ -1418,21 +1418,21 @@ def sim_nominal():
                             break
                         off += 1
             tb["wafer_angle"] = [ # Degrees
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
+                30.0,
+                30.0,
+                30.0,
+                -150.0,
+                -150.0,
+                30.0,
+                30.0,
+                30.0,
+                -30.0,
+                90.0,
+                30.0,
+                30.0,
             ]
             # 30 deg, 252 det/band
-            tb["platescale"] = 0.070946
+            tb["platescale"] = 0.070093/0.9855
             tb["FOV_cut"] = 30.0
         tb["toast_hex_pos"] = stube_toasthex_pos[tindx]
         tubes[nm] = tb

--- a/s4sim/hardware/config.py
+++ b/s4sim/hardware/config.py
@@ -1747,14 +1747,14 @@ def sim_nominal():
 
     #from the DSR
     sfwhm = OrderedDict()
-    sfwhm["SAT_f030"] = 85.2
-    sfwhm["SAT_f040"] = 61.6
-    sfwhm["SAT_f085"] = 24.6
-    sfwhm["SAT_f145"] = 15.8
-    sfwhm["SAT_f095"] = 22.4
-    sfwhm["SAT_f155"] = 14.3
-    sfwhm["SAT_f220"] = 9.4
-    sfwhm["SAT_f280"] = 7.7
+    sfwhm["SAT_f030"] = 100.9
+    sfwhm["SAT_f040"] = 74.4
+    sfwhm["SAT_f085"] = 29.5
+    sfwhm["SAT_f145"] = 18.1
+    sfwhm["SAT_f095"] = 26.4
+    sfwhm["SAT_f155"] = 16.9
+    sfwhm["SAT_f220"] = 11.3
+    sfwhm["SAT_f280"] = 10.1
 
     tele = OrderedDict()
     tele["tubes"] = ["ST0", "ST1", "ST2"]

--- a/s4sim/hardware/sim.py
+++ b/s4sim/hardware/sim.py
@@ -417,7 +417,7 @@ def sim_telescope_detectors(hw, tele, tubes=None):
 
             # Simulate the offset layout
             offset = qa.mult(
-                qa.rotation(XAXIS, -np.radians(waferspace * platescale / 2)),
+                qa.rotation(XAXIS, -np.radians(waferspace * platescale / np.sqrt(3))),
                 qa.rotation(ZAXIS, -thirty),
             )
             wcenters = hex_layout(


### PR DESCRIPTION
Phase I design for Chile SAT layouts using s4aggr+HWP design. Includes: Updated wafer layouts including pin holes, updated clocking for new wafer layouts in focal plane, fix for non-centered focal plane layout, and matched numbers of optically "good" detectors.

Still needs noise information and beams for Chile SAT design.