### PR TITLE
Split89

### DIFF
--- a/s4sim/hardware/config.py
+++ b/s4sim/hardware/config.py
@@ -1814,10 +1814,10 @@ def sim_nominal():
     sfwhm = OrderedDict()
     sfwhm["SAT_f030"] = 79.2
     sfwhm["SAT_f040"] = 56.6
-    sfwhm["SAT_f085"] = 23.6
-    sfwhm["SAT_f145"] = 15.0
-    sfwhm["SAT_f095"] = 21.2
-    sfwhm["SAT_f155"] = 13.9
+    sfwhm["SAT_f085"] = 22.9
+    sfwhm["SAT_f145"] = 14.2
+    sfwhm["SAT_f095"] = 20.6
+    sfwhm["SAT_f155"] = 13.5
     sfwhm["SAT_f090"] = 21.4
     sfwhm["SAT_f150"] = 14.0
     sfwhm["SAT_f220"] = 9.4


### PR DESCRIPTION
Instrument configuration for Splits 8 and 9. SO pixel pitch at LF/MF and larger optics plus larger FOV.